### PR TITLE
Add .wav as supported extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ mapping tables, the harvest of the tables when mapped and the preservation of
 old mappings when new lists are needed for later uploads.
 
 Alternatively you can make use of only the prep-uploader/uploader tools by
-creating your own indata file. This must then be a json file where each image
-is represented by a dictionary entry with the *original filename* (without
+creating your own indata file. This must then be a json file where each media
+file is represented by a dictionary entry with the *original filename* (without
 the file extension) as the key and the following values:
  - `info`: the wikitext to be used on the description page (e.g. an information
    template)

--- a/batchupload/postUpload.py
+++ b/batchupload/postUpload.py
@@ -22,7 +22,7 @@ def trim_parent_category(category, summary=None, verbose=True):
     @param verbose: if verbose output is desired. Default: True.
     @return: the number of pages removed from the category
     """
-    summary = 'Removing parent category when image already in subcategory'
+    summary = 'Removing parent category when file already in subcategory'
     load_commons_site()
     if not category.startswith('Category:'):
         category = 'Category:{0}'.format(category)
@@ -68,7 +68,7 @@ def trim_second_category(start_category, del_category, in_filename=None,
     if not del_category.startswith('Category:'):
         del_category = 'Category:{0}'.format(del_category)
     summary = summary or \
-        'Removing {del_category} for image already in {start_category}'.format(
+        'Removing {del_category} for file already in {start_category}'.format(
             del_category=del_category, start_category=start_category)
 
     start_cat = pywikibot.Category(commons, start_category)

--- a/batchupload/prepUpload.py
+++ b/batchupload/prepUpload.py
@@ -8,7 +8,7 @@ from batchupload.make_info import make_info_page
 import batchupload.common as common
 import pywikibot
 
-FILE_EXTS = ('.tif', '.jpg', '.tiff', '.jpeg')
+FILE_EXTS = ('.tif', '.jpg', '.tiff', '.jpeg', '.wav')
 
 
 def run(in_path, out_path, data_path, file_exts=None):

--- a/batchupload/uploader.py
+++ b/batchupload/uploader.py
@@ -107,9 +107,9 @@ def upload_single_file(file_name, media_file, text, target_site,
 def up_all(in_path, cutoff=None, target='Uploaded', file_exts=None,
            verbose=False, test=False, target_site=None, chunked=True):
     """
-    Upload all matched files in the supplied directory.
+    Upload all matched media files in the supplied directory.
 
-    Media (image) files and metadata files with the expected extension .info
+    Media files and metadata files with the expected extension .info
     should be in the same directory. Metadata files should contain the entirety
     of the desired description page (in wikitext).
 
@@ -197,9 +197,9 @@ def up_all_from_url(info_path, cutoff=None, target='upload_logs',
                     file_exts=None, verbose=False, test=False,
                     target_site=None, only=None, skip=None):
     """
-    Upload all images provided as urls in a make_info json file.
+    Upload all media files provided as urls in a make_info json file.
 
-    Media (image) files and metadata files with the expected extension .info
+    Media files and metadata files with the expected extension .info
     should be in the same directory. Metadata files should contain the entirety
     of the desired description page (in wikitext).
 

--- a/batchupload/uploader.py
+++ b/batchupload/uploader.py
@@ -8,7 +8,7 @@ from batchupload.make_info import make_info_page
 import os
 import pywikibot
 
-FILE_EXTS = ('.tif', '.jpg', '.tiff', '.jpeg')
+FILE_EXTS = ('.tif', '.jpg', '.tiff', '.jpeg', '.wav')
 URL_PROTOCOLS = ('http', 'https')  # @todo: extend with supported protocols
 
 

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -13,7 +13,7 @@ class TestVerifyUrlFileExtension(unittest.TestCase):
     """Test the verify_url_file_extension method."""
 
     def setUp(self):
-        self.file_exts = ('.tif', '.jpg', '.tiff', '.jpeg')
+        self.file_exts = ('.tif', '.jpg', '.tiff', '.jpeg', '.wav')
         self.protocols = ('http', 'https')
 
     def test_verify_url_file_extension_empty(self):


### PR DESCRIPTION
Add .wav to list of supported extensions.

In connection with the batch upload of audio files we've been doing:

https://commons.wikimedia.org/wiki/Category:Audio_files_from_the_Swedish_Performing_Arts_Agency

Task: https://phabricator.wikimedia.org/T219596